### PR TITLE
Improve responsiveness of landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,11 +25,11 @@
     }
     .plan {
       background: #fff;
-      padding: 15px;
+      padding: 20px;
       border-radius: 8px;
       width: 280px;
       box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-      margin-bottom: 20px;
+      margin-bottom: 24px;
     }
     .plan h3 {
       margin-top: 0;
@@ -89,29 +89,52 @@
       outline: none;
     }
 
+    #chatToggle {
+      display: none;
+    }
+
     @media (max-width: 600px) {
       body {
-        font-size: 14px;
+        font-size: 15px;
       }
       header {
-        padding: 15px 0;
+        padding: 20px 0;
       }
       .plans {
         flex-direction: column;
-        margin: 10px;
+        margin: 15px;
         align-items: stretch;
       }
       .plan {
         width: 100%;
-        margin-bottom: 15px;
+        margin-bottom: 20px;
       }
       #chatbox {
         bottom: 0;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
+        left: 0;
+        right: 0;
+        transform: none;
         width: 100%;
         border-radius: 8px 8px 0 0;
+        display: none;
+        max-height: 60vh;
+      }
+      #chatbox.open {
+        display: flex;
+      }
+      #chatToggle {
+        display: block;
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        background: #1976d2;
+        color: #fff;
+        border: none;
+        font-size: 24px;
+        cursor: pointer;
       }
     }
   </style>
@@ -148,10 +171,19 @@
       <button type="submit">Enviar</button>
     </form>
   </div>
+  <button id="chatToggle">💬</button>
 
   <script>
     const form = document.getElementById('chatInput');
     const messages = document.getElementById('chatMessages');
+    const chatbox = document.getElementById('chatbox');
+    const toggleBtn = document.getElementById('chatToggle');
+
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        chatbox.classList.toggle('open');
+      });
+    }
 
     form.addEventListener('submit', async function (e) {
       e.preventDefault();
@@ -161,6 +193,7 @@
 
       appendMessage('Tú', userText);
       input.value = '';
+      chatbox.classList.add('open');
 
       try {
         const res = await fetch('/api/gpt', {

--- a/index.html
+++ b/index.html
@@ -17,11 +17,16 @@
       padding: 20px 0;
       text-align: center;
     }
+    header h1 {
+      margin: 0;
+      font-size: 2em;
+    }
     .plans {
       display: flex;
       flex-wrap: wrap;
       justify-content: space-around;
       margin: 20px;
+      gap: 20px;
     }
     .plan {
       background: #fff;
@@ -99,15 +104,21 @@
       }
       header {
         padding: 20px 0;
+        text-align: center;
+      }
+      header h1 {
+        font-size: 1.6em;
       }
       .plans {
         flex-direction: column;
         margin: 15px;
         align-items: stretch;
+        gap: 20px;
       }
       .plan {
         width: 100%;
         margin-bottom: 20px;
+        padding: 18px;
       }
       #chatbox {
         bottom: 0;
@@ -171,7 +182,7 @@
       <button type="submit">Enviar</button>
     </form>
   </div>
-  <button id="chatToggle">💬</button>
+  <button id="chatToggle" aria-label="Abrir chat" type="button">💬</button>
 
   <script>
     const form = document.getElementById('chatInput');


### PR DESCRIPTION
## Summary
- tweak plan spacing and padding
- add floating chat toggle button on small screens
- hide chat by default on mobile and open with a button
- adjust font sizes and paddings for small screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f42ea034083289a58093d333297dd