### PR TITLE
Add floating chatbox button with toggle functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,10 +79,31 @@
       border: 1px solid #1976d2;
       border-radius: 12px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-      display: flex;
+      display: none;
       flex-direction: column;
       font-size: 14px;
       overflow: hidden;
+      z-index: 1000;
+    }
+    #chatbox.open {
+      display: flex;
+    }
+    #chatToggle {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      width: 56px;
+      height: 56px;
+      border: none;
+      border-radius: 50%;
+      background: #1976d2;
+      color: #fff;
+      font-size: 24px;
+      cursor: pointer;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
       z-index: 1000;
     }
     #chatMessages {
@@ -208,10 +229,17 @@
       <button type="submit">Enviar</button>
     </form>
   </div>
+  <button id="chatToggle">💬</button>
 
-  <script>
-    const form = document.getElementById('chatInput');
-    const messages = document.getElementById('chatMessages');
+    <script>
+      const form = document.getElementById('chatInput');
+      const messages = document.getElementById('chatMessages');
+      const chatbox = document.getElementById("chatbox");
+      const toggleButton = document.getElementById("chatToggle");
+
+      toggleButton.addEventListener("click", () => {
+        chatbox.classList.toggle("open");
+      });
 
     form.addEventListener('submit', async function (e) {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- add CSS rule for #chatbox.open and styling for #chatToggle button
- hide chatbox by default and show it when the button toggles
- insert floating toggle button in the HTML
- enable JS to toggle the chatbox

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f45aa81c88328af25a5fbc3c9ecff